### PR TITLE
Improving styling and guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ The existing ‘Defra Core’ theme has some accessibility issues and currently 
 
 To apply this additional styling:
 
-1. Go to ‘Look and feel’ and ensure that the 'Core Defra' theme is being used
-2. Navigate to the ‘Style’ panel
-3. The contents of the [Defra Qualtrics additional styling CSS](styling/defra-qualtrics-additional-styling.css) file can be pasted into the 'Custom CSS' field.
-4. Once complete, select the 'Apply' button.
+1. Go to ‘Look and feel’.
+2. Select the 'Core Defra' Dynamic Theme (not the static theme).
+3. Navigate to the ‘Style’ panel
+4. The contents of the [Defra Qualtrics additional styling CSS](styling/defra-qualtrics-additional-styling.css) file can be pasted into the 'Custom CSS' field.
+5. Once complete, select the 'Apply' button.
 
 ### Setting up your template
 Ensure that the button text used in your form is consistent.
@@ -69,6 +70,9 @@ Ensure that the button text used in your form is consistent.
 1. Go to ‘Look and feel’ and then ‘General’
 2. For the ‘Next button text’ delete the existing text and enter ‘Continue’.
 3. For the ‘Back button text’ delete the existing text and enter ‘Back’.
+
+#### If your survey only is a single page
+You should change the ‘Next button text’ to be 'Submit' rather than 'Continue'.
 
 The Progress bar will be hidden by default, regardless of the selected option.
 

--- a/accessibility-statement/qualtrics-generic-accessibility-statement.html
+++ b/accessibility-statement/qualtrics-generic-accessibility-statement.html
@@ -9,15 +9,26 @@
     <li>use most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
   </ul>
   <h2>How accessible this website is</h2>
-  <p>Based on general testing of the Qualtrics platform and guidance provided by the Defra accessibility team, this service should comply with the Web Content Accessibility Guidelines 2.1 AA success criteria.</p>
+  <p>We know some parts of these surveys are not fully accessible:</p>
+  <ul>
+  <li>Input fields requesting commonly used information will not allow for the use of autocomplete.</li>
+  <li>Progressing through the survey does not update the page title.</li>
+  <li>Error messages do not always provide a suggestion for accurately resolving an error.</li>
+  </ul>
   <h2>Feedback and contact information</h2>
   <p>Tell us if you need information in a different format.</p>
+  <ul>
+  <li>email -YOUR EMAIL ADDRESS-</li>
+  <li>call -PHONE NUMBER-</li>
+  <li>-ANY OTHER CONTACT DETAILS-</li>
+  </ul>
   <p>In your message, include:</p>
   <ul>
     <li>the web address (URL) of the content</li>
     <li>your email address and name</li>
     <li>the format you need - for example, plain text, braille, BSL, large print or audio CD</li>
   </ul>
+  <p>We'll consider your request and get back to you in 10 days.</p>
   <p>You can request a PDF in an accessible format from its page. Click ‘Request an accessible format’ to contact the organisation that published the document.</p>
   <p>You can also view the organisation’s accessible document policy to report any problems or request documents in an alternative format.</p>
   <h2>Reporting accessibility problems with this website</h2>
@@ -26,7 +37,7 @@
   <p>If you contact us with a complaint and you’re not happy with our response contact the Equality Advisory and Support Service (EASS).</p>
   <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).</p>
   <h2>Technical information about this website’s accessibility</h2>
-  <p>The Government Digital Service is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+  <p>-NAME OF DEPARTMENT- is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
   <h2>Compliance status</h2>
   <p>The service that has linked to this accessibility statement is partially compliant with the Web Content Accessibility Guidelines version 2.1 AA standard.</p>
   <h2>Non-accessible content</h2>

--- a/styling/defra-qualtrics-additional-styling.css
+++ b/styling/defra-qualtrics-additional-styling.css
@@ -43,6 +43,11 @@ a {
   font-size: 1.1875rem !important;
 }
 
+p,
+li{
+  margin-bottom: 1.25rem !important;
+}
+
 /* Implementing a font scale */
 h1 {
   font-size: 3rem !important;
@@ -77,6 +82,14 @@ h5 {
 h6 {
   font-size: 1rem;
   margin-bottom: 1.25rem !important;
+}
+
+:is(p, ul) + h2 {
+  padding-top: 1.25rem;
+}
+
+:is(p, ul) + :is(h3, h4, h5, h6) {
+  padding-top: 0.625rem;
 }
 
 /* Using the following rule to account for the mass of br tags that Qualtrics introduces causing lots of whitespace */
@@ -313,9 +326,6 @@ input[type="radio"]:focus + label.q-radio {
   padding-left: 0 !important;
   padding-right: 0 !important;
   line-height: 1.25 !important;
-}
-.Skin .QuestionText h2 {
-  padding-bottom: 0.625rem;
 }
 .Skin .QuestionText p {
   margin-top: 0.25rem;


### PR DESCRIPTION
Added the following changes:

## Within the CSS styling
* Updated spacing between content by adding in padding

## Within the accessibility statement
* Improved 'How accessible this website is' section
* Improved section for people to add contact details

## Within the general guidance
* Improved the description for selecting the right theme
* Added guidance for labelling buttons if you only have a single page

These changes will make up version 0.21 of the guidance.